### PR TITLE
links updated

### DIFF
--- a/docs/introduction-eclipse-adt/index.md
+++ b/docs/introduction-eclipse-adt/index.md
@@ -53,8 +53,8 @@ Da der Funktionsumfang der ABAP Development Tools fortlaufend durch SAP erweiter
 
 Für Cloud:
 
-[https://help.sap.com/docs/BTP/5371047f1273405bb46725a417f95433/ab03dcd9072f4a2d85c945d05929d3fb.html](https://help.sap.com/docs/BTP/5371047f1273405bb46725a417f95433/ab03dcd9072f4a2d85c945d05929d3fb.html)
+[List of Development Objects with an Eclipse-based Editor](https://help.sap.com/docs/btp/sap-abap-development-user-guide/list-of-development-objects-with-eclipse-based-editor)
 
 Für On-Premise:
 
-[https://help.sap.com/doc/2e9cf4a457d84c7a81f33d8c3fdd9694/Cloud/en-US/inst_guide_abap_development_tools.pdf](https://help.sap.com/doc/2e9cf4a457d84c7a81f33d8c3fdd9694/Cloud/en-US/inst_guide_abap_development_tools.pdf)
+[Installing ABAP Development Tools](https://help.sap.com/doc/2e9cf4a457d84c7a81f33d8c3fdd9694/Cloud/en-US/inst_guide_abap_development_tools.pdf)


### PR DESCRIPTION
The link for cloud got a new user friendly URL from SAP. The name of the link is List of Development Objects with an Eclipse-based Editor.

For on premise: the link goes to a document named Installing ABAP Development Tools

Using the title of the link target should make it easier for humans to read the link.