### PR TITLE
fix: metadata in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsag-adt-leitfaden",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "description": "DSAG ADT Leitfaden",
   "main": "--none",
   "repository": {
@@ -8,12 +8,12 @@
     "url": "git+https://github.com/1DSAG/ADT-Leitfaden.git"
   },
   "keywords": [
-    "UI5",
+    "ABAP",
     "DSAG",
-    "SAPUI5",
-    "openUI5"
+    "ADT",
+    "ABAP in Eclipse"
   ],
-  "author": "DSAG UI5 community",
+  "author": "DSAG ABAP community",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/1DSAG/ADT-Leitfaden/issues"

--- a/package.json
+++ b/package.json
@@ -18,11 +18,7 @@
   "bugs": {
     "url": "https://github.com/1DSAG/ADT-Leitfaden/issues"
   },
-  "homepage": "https://github.com/1DSAG/ADT-Leitfaden#readme",
-  "scripts": {
-    "addTemplate" : "node ./docs/addtempalte.js",
-    "convert2docx" : "node ./docs/convertdocx2md.js"
-  },
+  "homepage": "https://1dsag.github.io/ADT-Leitfaden/",
   "dependencies": {
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",


### PR DESCRIPTION
This PR corrects the metadata in the `package.json` file i.e.:

- The version is set to 1.0.0 as the guideline is released
- The keywords are adjusted to the ABAP specific context
- The author is adjusted to the ABAP community 