### PR TITLE
Feat: link issue update

### DIFF
--- a/.github/workflows/links-watcher-cron.yml
+++ b/.github/workflows/links-watcher-cron.yml
@@ -28,7 +28,6 @@ jobs:
         uses: micalevisk/last-issue-action@v2
         if: ${{ steps.lychee.outputs.exit_code }} != 0
         with:
-          title: Link Checker Report
           state: open
           labels: |
             broken link

--- a/.github/workflows/links-watcher-cron.yml
+++ b/.github/workflows/links-watcher-cron.yml
@@ -25,7 +25,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
       - name: Find existing issue
         id: find_issue
-        uses: peter-evans/find-issue@v1
+        uses: micalevisk/last-issue-action@v2
         if: ${{ steps.lychee.outputs.exit_code }} != 0
         with:
           title: Link Checker Report
@@ -38,7 +38,7 @@ jobs:
         if: ${{ steps.lychee.outputs.exit_code }} != 0
         with:
           title: Link Checker Report
-          # If issue number is empty a new issue gets created
+          # If issue number is empty a new issue gets
           issue-number: ${{ steps.find_issue.outputs.issue-number }}
           content-filepath: ./lychee/out.md
           labels: broken link, automated issue

--- a/.github/workflows/links-watcher-cron.yml
+++ b/.github/workflows/links-watcher-cron.yml
@@ -23,10 +23,22 @@ jobs:
           output: ./lychee/out.md
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Create issue when fail
+      - name: Find existing issue
+        id: find_issue
+        uses: peter-evans/find-issue@v1
+        if: ${{ steps.lychee.outputs.exit_code }} != 0
+        with:
+          title: Link Checker Report
+          state: open
+          labels: |
+            broken link
+            automated issue
+      - name: Create or update issue for broken links
         uses: peter-evans/create-issue-from-file@v4
         if: ${{ steps.lychee.outputs.exit_code }} != 0
         with:
           title: Link Checker Report
+          # If issue number is empty a new issue gets created
+          issue-number: ${{ steps.find_issue.outputs.issue-number }}
           content-filepath: ./lychee/out.md
           labels: broken link, automated issue

--- a/.github/workflows/links-watcher-cron.yml
+++ b/.github/workflows/links-watcher-cron.yml
@@ -2,7 +2,7 @@ name: Periodic Link Checker
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "30 0 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This PR contains the folowing enhancements of the workflow that checks the links in the repository markdown files:

- Change of cron schedule to once a week (Monday)
- Enhancement of issue creation logic to not create an issue if one is existing, but update the existing one

Current drawback: The action <https://github.com/micalevisk/last-issue-action> uses an outdated version of the @actions/core library. This causes warnings when the action is executing hinting to the deprecation notice for setting output in actions (see: <https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/>)
Will open a PR to get this fixed (and reference it here. As of now this is not an issue for the repo as the removal of the deprecated is due in June 2023