### PR TITLE
Bild des Autorenteams von den DSAG Technologietagen

### DIFF
--- a/docs/authors-appendix/index.md
+++ b/docs/authors-appendix/index.md
@@ -135,5 +135,5 @@ Senior Manager/ Entwicklungsleiter/ Agile Technical Coach</td>
 
 ![](./img/team_dsag_TechDays.jpg)  
 <span class="img-caption" markdown=1>
-*Abbildung: Teil des Autorenteams bei den DSAG Technologietagen in Mannheim*
+*Abbildung: Teil des Autorenteams bei den DSAG Technologietagen 2023 in Mannheim*
 </span>

--- a/docs/authors-appendix/index.md
+++ b/docs/authors-appendix/index.md
@@ -132,3 +132,8 @@ Senior Manager/ Entwicklungsleiter/ Agile Technical Coach</td>
 <tbody>
 </tbody>
 </table>
+
+![](./img/team_dsag_TechDays.jpg)  
+<span class="img-caption" markdown=1>
+*Abbildung: Teil des Autorenteams bei den DSAG Technologietagen in Mannheim*
+</span>


### PR DESCRIPTION
Ein Teil des Autorenteams war bei den Technologietagen in Mannheim. Das Gruppenfoto wurde zu den Autorenvorstellungen hinzugefügt.