### PR TITLE
#51 - repair broken links 

### DIFF
--- a/docs/further-information/index.md
+++ b/docs/further-information/index.md
@@ -28,7 +28,7 @@ WIP
 <tr class="header">
 <td>Sonstige</td>
 <td><p>Blog Post <a href="https://blogs.sap.com/2013/06/05/adt-feature-availability-matrix-for-as-abap-releases/">ADT Feature Availability Matrix for AS ABAP Releases</a></p>
-<p>Blog Posts <a href="https://people.sap.com/thomasfiedler#content:blogposts">ADT Product Owner</a></p></td>
+<p>Blog Posts <a href="https://community.sap.com/t5/user/viewprofilepage/user-id/4266">Beiträge SAP Community von Thomas Fiedler</a></p></td>  
 </tr>
 </thead>
 <tbody>

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,9 +13,14 @@ Wenn Sie einen Beitrag leisten möchten, besuchen Sie das GitHub Repository:
 
 Der DSAG ADT Leitfaden ist ein lebendiges Dokument 👨‍💻 - es lebt von und mit seiner Community 🥳.
 
-Der offizielle DSAG Leitfaden kann als PDF (Version 1.0) über das [DSAGNet](https://dsag.de/leistungen/wissen/sap-leitfaeden/) heruntergeladen werden.
+Dieser Leitfaden kann über die digitale Plattform "Impulsant" der DSAG als PDF (Version 1.0) unter folgendem Link heruntergeladen werden:  
+[https://impulsant-dsag.de/formate/textbeitrag/abap-development-tools-adt-in-eclipse](https://impulsant-dsag.de/formate/textbeitrag/abap-development-tools-adt-in-eclipse).
 
 {: .note}
-An English version can also be downloaded as a PDF (version 1.0) from [DSAGNet](https://dsag.de/leistungen/wissen/sap-leitfaeden/handbook-abap-development-tools/).
+An English version as PDF of this ADT Guide (version 1.0) is also available  under following link:  
+[https://impulsant-dsag.de/formate/textbeitrag/sap-handbook-abap-development-tools-in-eclipse](https://impulsant-dsag.de/formate/textbeitrag/sap-handbook-abap-development-tools-in-eclipse).
+
+Bitte beachten Sie, dass die PDF Versionen nicht zeitgleich mit dem Github Repository aktualisiert werden.  
+Stand 10/2024 handelt es sich bei den Aktualisierungen um Link-Updates und kleinere redaktionelle Anpassungen.  
 
 Den zu jederzeit aktuellen Stand des Leitfadens finden sie im Folgenden.


### PR DESCRIPTION
Link checker Report vom August. Links geprüft und fehler behoben.
PDF in Impulsant.
Die Errors von SAP Learning lassen sich nicht nachvollziehen